### PR TITLE
add uncommadash to parse pos_res_atoms and a little fix in input parser to convert tuple back to string

### DIFF
--- a/OpenMM-MD.py
+++ b/OpenMM-MD.py
@@ -872,14 +872,17 @@ class RestartReporter(object):
             v0 = Vfin * nanometer / picosecond
             frc = simulation.context.getState(getForces=True).getForces()
             # Obtain masses.
-            mass = []
+            rev_mass = []
             for i in range(simulation.context.getSystem().getNumParticles()):
-                mass.append(simulation.context.getSystem().getParticleMass(i)/dalton)
-            mass *= dalton
+                mass = simulation.context.getSystem().getParticleMass(i)/dalton
+                r_mass = 1.0/mass if mass > 0 else 0
+                rev_mass.append(r_mass)
+            rev_mass /= dalton
+            
             # Get accelerations.
             accel = []
             for i in range(simulation.context.getSystem().getNumParticles()):
-                accel.append(frc[i] / mass[i] / (kilojoule/(nanometer*mole*dalton)))# / (kilojoule/(nanometer*mole*dalton)))
+                accel.append(frc[i] * rev_mass[i] / (kilojoule/(nanometer*mole*dalton)))# / (kilojoule/(nanometer*mole*dalton)))
             accel *= kilojoule/(nanometer*mole*dalton)
             # Propagate velocities backward by half a time step.
             dv = femtosecond * accel

--- a/OpenMM-MD.py
+++ b/OpenMM-MD.py
@@ -51,6 +51,8 @@ warnings.simplefilter("ignore")
 import logging
 logging.basicConfig()
 
+
+sys.setrecursionlimit(10000)
 #================================#
 #       Set up the logger        #
 #================================#

--- a/OpenMM-MD.py
+++ b/OpenMM-MD.py
@@ -689,6 +689,7 @@ class SimulationOptions(object):
         self.set_active('cent_res_k_per_atom',1e5,float,"Set the force constant for the centroid restraints.")
         self.set_active('cent_res_atoms',None,str,"Set the indices of the atoms whose center will be restrained to their original position.", depend=(self.cent_res_k_per_atom > 0),msg="Restrain force constants k must > 0")
         self.set_active('cent_res_atoms2',None,str,"Set the indices of the atoms whose center will be restrained to their original position.", depend=(self.cent_res_k_per_atom > 0),msg="Restrain force constants k must > 0")
+        self.set_active('cent_res_xy_atoms',None,str,"Set the indices of the atoms whose center on the x and y direction will be restrained to their original position.", depend=(self.cent_res_k_per_atom > 0),msg="Restrain force constants k must > 0")
         self.set_active('remove_cm_motion',True,bool,"Remove Center of Mass Motion every Step.")
         self.set_active('group_up_pressure',1.0,float,"Pressue on the group of atoms along z direction. Unit: bar")
         self.set_active('group_up_atoms',None,str,"Set the indices of the atoms in Group to be pushed upwards.", depend=(self.group_up_pressure>0), msg="Group Up Pressure must > 0")
@@ -1101,6 +1102,16 @@ else:
         cent_force.addPerBondParameter('y0')
         cent_force.addPerBondParameter('z0')
         cent_force.addBond([g1], [args.cent_res_k_per_atom*len(particles), x0,y0,z0])
+        system.addForce(cent_force)
+    if args.cent_res_xy_atoms:
+        cent_force = openmm.CustomCentroidBondForce(1, "k*((x1-x0)^2 + (y1-y0)^2)")
+        particles = uncommadash(args.cent_res_xy_atoms)
+        cent_force.addPerBondParameter('k')
+        g1 = cent_force.addGroup(particles)
+        x0, y0, z0 = np.average([pdb.positions[i] for i in particles] , axis=0)
+        cent_force.addPerBondParameter('x0')
+        cent_force.addPerBondParameter('y0')
+        cent_force.addBond([g1], [args.cent_res_k_per_atom*len(particles), x0,y0])
         system.addForce(cent_force)
 
     #====================================#

--- a/OpenMM-MD.py
+++ b/OpenMM-MD.py
@@ -29,6 +29,7 @@ this program.  If not, see <http://www.gnu.org/licenses/>.
 #| Global Imports |#
 #==================#
 
+from __future__ import print_function, division
 import time
 from datetime import datetime, timedelta
 t0 = time.time()
@@ -261,18 +262,18 @@ def printcool(text,sym="#",bold=False,color=2,ansi=None,bottom='-',minwidth=50):
     text = text.split('\n')
     width = max(minwidth,max([newlen(line) for line in text]))
     bar = ''.join([sym for i in range(width + 8)])
-    print '\n'+bar
+    print('\n'+bar)
     for line in text:
         padleft = ' ' * ((width - newlen(line)) / 2)
         padright = ' '* (width - newlen(line) - len(padleft))
         if ansi != None:
             ansi = str(ansi)
-            print "%s| \x1b[%sm%s" % (sym, ansi, padleft),line,"%s\x1b[0m |%s" % (padright, sym)
+            print("%s| \x1b[%sm%s" % (sym, ansi, padleft),line,"%s\x1b[0m |%s" % (padright, sym))
         elif color != None:
-            print "%s| \x1b[%s9%im%s" % (sym, bold and "1;" or "", color, padleft),line,"%s\x1b[0m |%s" % (padright, sym)
+            print("%s| \x1b[%s9%im%s" % (sym, bold and "1;" or "", color, padleft),line,"%s\x1b[0m |%s" % (padright, sym))
         else:
             warn_press_key("Inappropriate use of printcool")
-    print bar
+    print(bar)
     return sub(sym,bottom,bar)
 
 def printcool_dictionary(Dict,title="General options",bold=False,color=2,keywidth=25,topwidth=50):
@@ -292,10 +293,10 @@ def printcool_dictionary(Dict,title="General options",bold=False,color=2,keywidt
         #print "\'%%-%is\' %% '%s'" % (keywidth,str.replace("'","\\'").replace('"','\\"'))
         return eval("\'%%-%is\' %% '%s'" % (keywidth,str.replace("'","\\'").replace('"','\\"')))
     if isinstance(Dict, OrderedDict):
-        print '\n'.join(["%s %s " % (magic_string(str(key)),str(Dict[key])) for key in Dict if Dict[key] != None])
+        print('\n'.join(["%s %s " % (magic_string(str(key)),str(Dict[key])) for key in Dict if Dict[key] != None]))
     else:
-        print '\n'.join(["%s %s " % (magic_string(str(key)),str(Dict[key])) for key in sorted([i for i in Dict]) if Dict[key] != None])
-    print bar
+        print('\n'.join(["%s %s " % (magic_string(str(key)),str(Dict[key])) for key in sorted([i for i in Dict]) if Dict[key] != None]))
+    print(bar)
 
 def EnergyDecomposition(Sim, verbose=False):
     # Before using EnergyDecomposition, make sure each Force is set to a different group.
@@ -346,10 +347,10 @@ def MTSVVVRIntegrator(temperature, collision_rate, timestep, system, ninnersteps
     for i in system.getForces():
         if i.__class__.__name__ in ["NonbondedForce", "CustomNonbondedForce", "AmoebaVdwForce", "AmoebaMultipoleForce"]:
             # Slow force.
-            print i.__class__.__name__, "is a Slow Force"
+            print(i.__class__.__name__, "is a Slow Force")
             i.setForceGroup(1)
         else:
-            print i.__class__.__name__, "is a Fast Force"
+            print(i.__class__.__name__, "is a Fast Force")
             # Fast force.
             i.setForceGroup(0)
 
@@ -732,13 +733,13 @@ def add_argument(group, *args, **kwargs):
             kwargs['help'] = d
     group.add_argument(*args, **kwargs)
 
-print
-print " #===========================================#"
-print " #|    OpenMM general purpose simulation    |#"
-print " #| (Hosted @ github.com/leeping/OpenMM-MD) |#"
-print " #|  Use the -h argument for detailed help  |#"
-print " #===========================================#"
-print
+print()
+print( " #===========================================#")
+print( " #|    OpenMM general purpose simulation    |#")
+print( " #| (Hosted @ github.com/leeping/OpenMM-MD) |#")
+print( " #|  Use the -h argument for detailed help  |#")
+print( " #===========================================#")
+print()
 
 parser = argparse.ArgumentParser()
 add_argument(parser, 'pdb', nargs=1, metavar='input.pdb', help='Specify one PDB or AMBER inpcrd file \x1b[1;91m(Required)\x1b[0m', type=str)
@@ -864,8 +865,8 @@ class EnergyReporter(object):
         self.run_time = float(simulation.currentStep - self._first) * args.timestep * femtosecond
         self.eda = EnergyDecomposition(simulation)
         if self._initial:
-            print >> self._out, ' '.join(["%25s" % i for i in ['#Time(ps)'] + self.eda.keys()])
-        print >> self._out, ' '.join(["%25.10f" % i for i in [self.run_time/picosecond] + self.eda.values()])
+            print(' '.join(["%25s" % i for i in ['#Time(ps)'] + self.eda.keys()]), file=self._out)
+        print(' '.join(["%25.10f" % i for i in [self.run_time/picosecond] + self.eda.values()]), file=self._out)
         self._initial = False
 
     def __del__(self):
@@ -1381,13 +1382,13 @@ for f in simulation.context.getSystem().getForces():
 
 # Print the sample input file here.
 for line in args.record():
-    print line
+    print(line)
 
 #===============================================================#
 #| Run dynamics for equilibration, or load restart information |#
 #===============================================================#
 if os.path.exists(args.restart_filename) and args.read_restart:
-    print "Restarting simulation from the restart file."
+    print("Restarting simulation from the restart file.")
     # Load information from the restart file.
     r_positions, r_velocities, r_boxes = pickle.load(open(args.restart_filename))
     # NOTE: Periodic box vectors must be set FIRST
@@ -1424,7 +1425,7 @@ if os.path.exists(args.restart_filename) and args.read_restart:
 else:
     # Set initial positions.
     simulation.context.setPositions(modeller.positions)
-    print "Initial potential is:", simulation.context.getState(getEnergy=True).getPotentialEnergy()
+    print("Initial potential is:", simulation.context.getState(getEnergy=True).getPotentialEnergy())
     if args.integrator != 'mtsvvvr':
         eda = EnergyDecomposition(simulation)
         eda_kcal = OrderedDict([(i, "%10.4f" % (j/4.184)) for i, j in eda.items()])
@@ -1432,11 +1433,11 @@ else:
 
     # Minimize the energy.
     if args.minimize:
-        print "Minimization start, the energy is:", simulation.context.getState(getEnergy=True).getPotentialEnergy()
+        print("Minimization start, the energy is:", simulation.context.getState(getEnergy=True).getPotentialEnergy())
         simulation.minimizeEnergy()
-        print "Minimization done, the energy is", simulation.context.getState(getEnergy=True).getPotentialEnergy()
+        print("Minimization done, the energy is", simulation.context.getState(getEnergy=True).getPotentialEnergy())
         positions = simulation.context.getState(getPositions=True).getPositions()
-        print "Minimized geometry is written to 'minimized.pdb'"
+        print("Minimized geometry is written to 'minimized.pdb'")
         PDBFile.writeModel(modeller.topology, positions, open('minimized.pdb','w'))
     # Assign velocities.
     if args.gentemp > 0.0:
@@ -1510,6 +1511,6 @@ prodtime = time.time() - t1
 #=============================================#
 logger.info('Getting statistics for the production run.')
 simulation.reporters[0].analyze(simulation)
-print "Total wall time: % .4f seconds" % (time.time() - t0)
-print "Production wall time: % .4f seconds" % (prodtime)
-print "Simulation speed: % .6f ns/day" % (86400*args.production*args.timestep*femtosecond/nanosecond/(prodtime))
+print("Total wall time: % .4f seconds" % (time.time() - t0))
+print("Production wall time: % .4f seconds" % (prodtime))
+print("Simulation speed: % .6f ns/day" % (86400*args.production*args.timestep*femtosecond/nanosecond/(prodtime)))

--- a/OpenMM-MD.py
+++ b/OpenMM-MD.py
@@ -1202,7 +1202,7 @@ def add_barostat():
             logger.info("This is a constant pressure (NPT) run at %.2f atm pressure" % args.pressure)
             logger.info("Adding Monte Carlo barostat with volume adjustment interval %i" % args.nbarostat)
             logger.info("Anisotropic box scaling is %s" % args.anisotropic)
-            if args.anisotropic != 'None':
+            if args.anisotropic != None:
                 #logger.info("Only the Z-axis will be adjusted")
                 adjust_x = 'x' in args.anisotropic
                 adjust_y = 'y' in args.anisotropic

--- a/OpenMM-MD.py
+++ b/OpenMM-MD.py
@@ -638,7 +638,7 @@ class SimulationOptions(object):
                         clash=(self.temperature <= 0.0),
                         msg="For constant pressure simulations, the temperature must be finite")
         self.set_active('anisotropic','None',str,"Specify 'x' and/or 'y' and/or 'z' for anisotropic box scaling in NPT simulations",
-                        depend=("pressure" in self.ActiveOptions and self.pressure > 0.0), msg = "We're not running a constant pressure simulation", allowed=['None','x','y','z','xy','xz','yz','xyz'])
+                        depend=("pressure" in self.ActiveOptions and self.pressure > 0.0), msg = "We're not running a constant pressure simulation", allowed=[None,'x','y','z','xy','xz','yz','xyz'])
         self.set_active('nbarostat',25,int,"Step interval for MC barostat volume adjustments.",
                         depend=("pressure" in self.ActiveOptions and self.pressure > 0.0), msg = "We're not running a constant pressure simulation")
         self.set_active('nonbonded_method','PME',str,"Set the method for nonbonded interactions.", allowed=["NoCutoff","CutoffNonPeriodic","CutoffPeriodic","Ewald","PME"])
@@ -878,7 +878,7 @@ class RestartReporter(object):
                 r_mass = 1.0/mass if mass > 0 else 0
                 rev_mass.append(r_mass)
             rev_mass /= dalton
-            
+
             # Get accelerations.
             accel = []
             for i in range(simulation.context.getSystem().getNumParticles()):

--- a/OpenMM-MD.py
+++ b/OpenMM-MD.py
@@ -1402,7 +1402,9 @@ logger.info("Total system charge   : %.5f elementary charge" % (compute_total_ch
 for f in simulation.context.getSystem().getForces():
     if f.__class__.__name__ == 'AmoebaMultipoleForce':
         logger.info("AMOEBA PME order      : %i" % f.getPmeBSplineOrder())
-        logger.info("AMOEBA PME grid       : %s" % str(f.getPmeGridDimensions()))
+        pme_params = f.getPMEParametersInContext(simulation.context)
+        logger.info("AMOEBA PME grid       : %s" % str(pme_params[1:]))
+        logger.info("AMOEBA PME aEwald     : %.5f" % pme_params[0])
     if f.__class__.__name__ == 'NonbondedForce':
         method_names = ["NoCutoff", "CutoffNonPeriodic", "CutoffPeriodic", "Ewald", "PME"]
         logger.info("Nonbonded method      : %s" % method_names[f.getNonbondedMethod()])

--- a/OpenMM-MD.py
+++ b/OpenMM-MD.py
@@ -637,7 +637,7 @@ class SimulationOptions(object):
         self.set_active('pressure',0.0,float,"Simulation pressure; set a positive number to activate.",
                         clash=(self.temperature <= 0.0),
                         msg="For constant pressure simulations, the temperature must be finite")
-        self.set_active('anisotropic','None',str,"Specify 'x' and/or 'y' and/or 'z' for anisotropic box scaling in NPT simulations",
+        self.set_active('anisotropic',None,str,"Specify 'x' and/or 'y' and/or 'z' for anisotropic box scaling in NPT simulations",
                         depend=("pressure" in self.ActiveOptions and self.pressure > 0.0), msg = "We're not running a constant pressure simulation", allowed=[None,'x','y','z','xy','xz','yz','xyz'])
         self.set_active('nbarostat',25,int,"Step interval for MC barostat volume adjustments.",
                         depend=("pressure" in self.ActiveOptions and self.pressure > 0.0), msg = "We're not running a constant pressure simulation")

--- a/OpenMM-MD.py
+++ b/OpenMM-MD.py
@@ -1022,7 +1022,7 @@ else:
     ex_force.addPerParticleParameter('z0')
     # Add force for each atom using there position
     for atom_idx in uncommadash(args.pos_res_atoms):
-        ex_force.addParticle(atom_idx-1, pdb.positions[atom_idx-1])
+        ex_force.addParticle(atom_idx, pdb.positions[atom_idx])
     system.addForce(ex_force)
 
 

--- a/OpenMM-MD.py
+++ b/OpenMM-MD.py
@@ -672,8 +672,7 @@ class SimulationOptions(object):
         self.set_active('cent_res_atoms',None,str,"Set the indices of the atoms whose center will be restrained to their original position.", depend=(self.cent_res_k > 0),msg="Restrain force constants k must > 0")
         self.set_active('remove_cm_motion',True,bool,"Remove Center of Mass Motion every Step.")
         self.set_active('group1',None,str,"Set the indices of the atoms in Group 1")
-        self.set_active('group2',None,str,"Set the indices of the atoms in Group 2")
-        self.set_active('f_betw_groups',1.0,float,"Force between Group 1 and Group 2", depend=(self.group1 and self.group2),msg="group1 and group2 must be specified!")
+        self.set_active('f_betw_groups',1.0,float,"Force between Group 1 and Group 2", depend=self.group1, msg="group1 and group2 must be specified!")
 
 #================================#
 #    The command line parser     #
@@ -1063,14 +1062,12 @@ else:
     #| Add CentroidForce Between Two Groups    |#
     #===========================================#
     if args.f_betw_groups:
-        print("Adding Force %f Between Groups %s and %s"%(args.f_betw_groups,args.group1,args.group2))
-        cent_force = openmm.CustomCentroidBondForce(2, "k*distance(g1,g2)")
+        print("Adding Force %f on Group %s"%(args.f_betw_groups,args.group1))
+        cent_force = openmm.CustomCentroidBondForce(1, "-k*z1")
         particles1 = uncommadash(args.group1)
-        particles2 = uncommadash(args.group2)
         cent_force.addPerBondParameter('k')
         g1 = cent_force.addGroup(particles1)
-        g2 = cent_force.addGroup(particles2)
-        cent_force.addBond([g1,g2],[args.f_betw_groups])
+        cent_force.addBond([g1],[args.f_betw_groups])
         system.addForce(cent_force)
 
 

--- a/OpenMM-MD.py
+++ b/OpenMM-MD.py
@@ -447,6 +447,8 @@ class SimulationOptions(object):
         if val != None and type(val) is not typ:
             if type(val) in [tuple, list] and typ is str:
                 val = ','.join([str(v) for v in val])
+            elif type(val) in [int, float] and typ is str:
+                val = str(val)
             else:
                 raise Exception("Tried to set option \x1b[1;91m%s\x1b[0m to \x1b[94m%s\x1b[0m but it's not the right type (%s required)" % (key, str(val), str(typ)))
         if depend and not clash:


### PR DESCRIPTION
The option pos_res_atoms is now string type. If a list of atoms has been parsed by leval() to form a tuple, convert this val back to string before checking if the types match. Finally use uncommadash to turn the string into a list of indices, each -1.
